### PR TITLE
Ajuste na paginação: ocultar botões para uma única página

### DIFF
--- a/components/CharacterResults.js
+++ b/components/CharacterResults.js
@@ -51,13 +51,13 @@ export default {
       </div>
 
       <!-- Controles de navegação -->
-      <div class="pagination">
+      <div class="pagination" v-if="totalPages > 1">
         <button @click="previousPage" :disabled="currentPage == 0">Anterior</button>
         <button @click="nextPage" :disabled="currentPage == totalPages - 1">Próximo</button>
       </div>
 
       <!-- Paginação -->
-      <div class="page-numbers">
+      <div class="page-numbers" v-if="totalPages > 1">
         <button 
           v-for="(page, index) in totalPages" 
           :key="index" 
@@ -66,6 +66,5 @@ export default {
           {{ index + 1 }}
         </button>
       </div>
-    </div>
-  `
+    </div>`
 };


### PR DESCRIPTION
- Adicionado comportamento para ocultar os botões de paginação quando houver apenas uma página de resultados.
- Melhora a usabilidade e a aparência da interface em casos de poucos resultados.
- Testado e funcional, pronto para revisão.
- Nota: Nenhuma outra funcionalidade foi alterada, foco apenas na lógica de exibição dos botões de navegação.